### PR TITLE
Add legal opportunity tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,9 @@ import streamlit as st
 import pandas as pd
 from pathlib import Path
 from datetime import datetime
-import os
+
+# Local modules
+from src.opportunities import load_opportunities, add_opportunity
 
 # Configure Streamlit page
 st.set_page_config(
@@ -145,15 +147,53 @@ def show_job_search():
 def show_applications():
     """Display applications management"""
     st.header("📨 Applications")
-    
-    st.info("🚧 Application management functionality will be implemented here.")
-    st.markdown("""
-    **Features to be implemented:**
-    - View all job applications
-    - Track application status
-    - Generate tailored CVs and cover letters
-    - Send applications via API
-    """)
+
+    st.subheader("Add New Opportunity")
+
+    # A form keeps the interface tidy and only saves when explicitly submitted.
+    with st.form("opportunity_form"):
+        title = st.text_input("Position Title")
+        organisation = st.text_input("Organisation")
+        opportunity_type = st.selectbox(
+            "Opportunity Type",
+            [
+                "Internship",
+                "Clerkship",
+                "Research",
+                "Court Shadowing",
+                "Networking",
+            ],
+        )
+
+        st.markdown("### Required Documents")
+        transcript = st.checkbox("Transcript")
+        references = st.checkbox("References")
+        writing_sample = st.checkbox("Writing Sample")
+        bar_status = st.text_input("Bar Status")
+
+        submitted = st.form_submit_button("Save Opportunity")
+
+    if submitted:
+        opportunity = {
+            "title": title,
+            "organisation": organisation,
+            "opportunity_type": opportunity_type,
+            "transcript": transcript,
+            "references": references,
+            "writing_sample": writing_sample,
+            "bar_status": bar_status,
+            "date_added": datetime.now().isoformat(),
+        }
+        add_opportunity(opportunity)
+        st.success("Opportunity saved")
+
+    # Display existing opportunities for quick reference.
+    opportunities = load_opportunities()
+    if opportunities:
+        st.subheader("Tracked Opportunities")
+        st.dataframe(pd.DataFrame(opportunities))
+    else:
+        st.info("No opportunities tracked yet.")
 
 def show_settings():
     """Display settings page"""

--- a/src/opportunities.py
+++ b/src/opportunities.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+"""Utility functions for storing and retrieving tracked opportunities.
+
+This module centralises file access so the Streamlit UI can remain clean and
+focus on presentation. Opportunities are stored in a JSON array where each
+entry represents a single application record.
+"""
+
+from pathlib import Path
+import json
+from typing import List, Dict, Any
+
+# Default location for stored opportunities. The parent directory is created
+# automatically if it does not yet exist.
+DATA_PATH = Path("data/opportunities.json")
+
+
+def load_opportunities(path: Path = DATA_PATH) -> List[Dict[str, Any]]:
+    """Load opportunity records from *path*.
+
+    Parameters
+    ----------
+    path:
+        Optional custom path to the opportunities JSON file.
+    """
+    if path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return []
+
+
+def save_opportunities(opportunities: List[Dict[str, Any]], path: Path = DATA_PATH) -> None:
+    """Persist *opportunities* to disk as formatted JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(opportunities, indent=2), encoding="utf-8")
+
+
+def add_opportunity(opportunity: Dict[str, Any], path: Path = DATA_PATH) -> None:
+    """Append a single *opportunity* to the stored collection."""
+    opportunities = load_opportunities(path)
+    opportunities.append(opportunity)
+    save_opportunities(opportunities, path)


### PR DESCRIPTION
## Summary
- add legal opportunity tracker with form for opportunity type and document requirements
- store tracked opportunities in JSON for later retrieval

## Testing
- `python -m py_compile app.py src/opportunities.py`

------
https://chatgpt.com/codex/tasks/task_e_68be2438f550832f9ad12c7f31e8996a