### PR TITLE
chore: enforce code standards & add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Guard billing
+        if: github.actor != 'letter-orgz'
+        run: |
+          echo "CI aborted: unauthorized actor" >&2
+          exit 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', 'pyproject.toml') }}
+          restore-keys: ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt ruff mypy pytest pytest-cov
+
+      - name: Run ruff
+        run: ruff .
+
+      - name: Run mypy
+        run: mypy .
+
+      - name: Run tests
+        run: pytest --cov=. --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        if: env.CODECOV_TOKEN != ''
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ env.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.5
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        args: [--ignore-missing-imports]

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,24 @@
+# Environment Variables
+
+| Variable | Purpose | Required | Default |
+|----------|---------|----------|---------|
+| `PERPLEXITY_API_KEY` | Access key for Perplexity job search API. | No | `` |
+| `MODEL` | Perplexity model selection. | No | `sonar-pro` |
+| `PERPLEXITY_API_URL` | Override endpoint for Perplexity API. | No | `` |
+| `ENABLE_PERPLEXITY` | Toggle Perplexity integrations. | No | `false` |
+| `APP_DB` | Path to application database. | No | `./db/app.db` |
+| `JOB_O_MATIC_DATABASE_URL` | SQLAlchemy connection string for main app database. | No | `sqlite:///data/jobs.db` |
+| `GREENHOUSE_API_KEY` | API key for Greenhouse submissions. | No | `` |
+| `LEVER_API_KEY` | API key for Lever submissions. | No | `` |
+| `CANDIDATE_FIRST_NAME` | Applicant first name. | Yes | `Omar` |
+| `CANDIDATE_LAST_NAME` | Applicant last name. | Yes | `Runjanally` |
+| `CANDIDATE_EMAIL` | Applicant contact email. | Yes | `your_email@example.com` |
+| `CANDIDATE_PHONE` | Applicant contact phone. | Yes | `+44 XXX XXX XXXX` |
+| `API_RATE_LIMIT` | Requests per second cap for external APIs. | No | `0.2` |
+| `ENABLE_AUTO_SUBMIT` | Allow automatic job application submission. | No | `false` |
+| `REQUIRE_HUMAN_CONFIRMATION` | Require manual approval before sending applications. | No | `true` |
+| `DATA_RETENTION_DAYS` | Days to retain stored data. | No | `90` |
+| `GITHUB_REPOSITORY_OWNER` | Owner for PR merge reports. | No | `letter-orgz` |
+| `GITHUB_REPOSITORY_NAME` | Repository name for PR merge reports. | No | `job-O-matic-` |
+| `GITHUB_TOKEN` | GitHub API token for PR merge checks. | No | `` |
+| `STREAMLIT_HEADLESS` | Disable Streamlit server GUI when set. | No | `0` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.black]
+line-length = 88
+target-version = ['py311']
+
+[tool.isort]
+profile = 'black'
+line_length = 88
+
+[tool.ruff]
+line-length = 88
+target-version = 'py311'
+
+[tool.mypy]
+python_version = '3.11'
+ignore_missing_imports = true

--- a/tests/test_app_loads.py
+++ b/tests/test_app_loads.py
@@ -1,0 +1,9 @@
+"""Basic import test for Streamlit app."""
+import os
+import sys
+from pathlib import Path
+
+def test_app_loads():
+    os.environ["STREAMLIT_HEADLESS"] = "1"
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    __import__("app")


### PR DESCRIPTION
## Summary
- add Black/isort/ruff/mypy config
- run lint, type, test in CI with billing guard
- document environment variables and add app import test

## Testing
- `ruff check .` *(fails: F821 and more)*
- `mypy .` *(fails: duplicate module named "script")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be345e271c832fb7c1d1ab38b75d3d